### PR TITLE
Add a total counter for smash or pass and a percentage

### DIFF
--- a/public/js/script.js
+++ b/public/js/script.js
@@ -60,8 +60,8 @@ smash.addEventListener('click', (e) => {
     smash.disabled = true;
     const pokemon = JSON.parse(sessionStorage.getItem('pokemon'));
     const smashOrPass = JSON.parse(sessionStorage.getItem('smashOrPass'));
-    var smashCount = JSON.parse(sessionStorage.getItem('smashCount'));
-    var passCount = JSON.parse(sessionStorage.getItem('passCount'));
+    let smashCount = JSON.parse(sessionStorage.getItem('smashCount'));
+    let passCount = JSON.parse(sessionStorage.getItem('passCount'));
 
     if (e.isTrusted) {
         // push to array
@@ -100,8 +100,8 @@ pass.addEventListener('click', (e) => {
     pass.disabled = true;
     const pokemon = JSON.parse(sessionStorage.getItem('pokemon'));
     const smashOrPass = JSON.parse(sessionStorage.getItem('smashOrPass'));
-    var passCount = JSON.parse(sessionStorage.getItem('passCount'));
-    var smashCount = JSON.parse(sessionStorage.getItem('smashCount'));
+    let passCount = JSON.parse(sessionStorage.getItem('passCount'));
+    let smashCount = JSON.parse(sessionStorage.getItem('smashCount'));
 
     if (e.isTrusted) {
         // push to array

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -11,6 +11,8 @@ const currentPokemon = sessionStorage.getItem('currentPokemon');
 fetch('/api/pokemon').then(res => res.json()).then(data => {
     if (!sessionStorage.getItem('pokemon')) sessionStorage.setItem('pokemon', JSON.stringify(data));
     if (!sessionStorage.getItem('smashOrPass')) sessionStorage.setItem('smashOrPass', '[]');
+    if (!sessionStorage.getItem('smashCount')) sessionStorage.setItem('smashCount', 0);
+    if (!sessionStorage.getItem('passCount')) sessionStorage.setItem('passCount', 0);
     sessionStorage.setItem('pokemonLength', data.length);
 }).then(() => {
     const pokemon = JSON.parse(sessionStorage.getItem('pokemon'));
@@ -29,6 +31,25 @@ fetch('/api/pokemon').then(res => res.json()).then(data => {
             item.type === 'smash' ? smashPokemon.innerHTML += `<em><p>${item.name}</p></em>` : passPokemon.innerHTML += `<em><p>${item.name}</p></em>`;
         })
     }
+    // Get the smash count
+    if (sessionStorage.getItem('smashCount') >= 0) {
+        const smashCount = JSON.parse(sessionStorage.getItem('smashCount'));
+        smashNum.innerHTML = "Total: " + smashCount;
+    }
+    // Get the pass count
+    if (sessionStorage.getItem('passCount') >= 0) {
+        const passCount = JSON.parse(sessionStorage.getItem('passCount'));
+        passNum.innerHTML = "Total: " + passCount;
+    }
+
+    // Only calculate the percentage if a button has been pressed once
+    if (sessionStorage.getItem('smashCount') + sessionStorage.getItem('passCount') > 0) { 
+        const smashCount = JSON.parse(sessionStorage.getItem('smashCount'));
+        const passCount = JSON.parse(sessionStorage.getItem('passCount'));
+
+        smashPercentage.innerHTML = Math.round((smashCount / (smashCount + passCount)) * 100) + "% Smash";
+    }
+    
 }).catch(err => {
     alert('An error has occurred. Check developer console for more details.');
     console.log(err);
@@ -39,12 +60,22 @@ smash.addEventListener('click', (e) => {
     smash.disabled = true;
     const pokemon = JSON.parse(sessionStorage.getItem('pokemon'));
     const smashOrPass = JSON.parse(sessionStorage.getItem('smashOrPass'));
+    var smashCount = JSON.parse(sessionStorage.getItem('smashCount'));
+    var passCount = JSON.parse(sessionStorage.getItem('passCount'));
 
     if (e.isTrusted) {
         // push to array
         smashOrPass.push(JSON.stringify({type: "smash", name: sessionStorage.getItem('currentPokemon') ?? 'bulbasaur'}));
+        // add to counter
+        smashCount++;
         // add to list
         smashPokemon.innerHTML += `<em><p>${sessionStorage.getItem('currentPokemon') ?? 'bulbasaur'}</p></em>`;
+        // add to displayed number
+        smashNum.innerHTML = "Total: " + smashCount;
+
+        // Display the percentage
+        smashPercentage.innerHTML = Math.round((smashCount / (smashCount + passCount)) * 100) + "% Smash";
+
         // if current pokemon is the same or doesn't exist
         if (currentPokemon === pokemon[0] || currentPokemon === null) pokemon.shift();
         // set session storage for current pokemon
@@ -52,6 +83,7 @@ smash.addEventListener('click', (e) => {
         pokemonName.innerText = sessionStorage.getItem('currentPokemon');
         // set session storage for smash or pass
         sessionStorage.setItem('smashOrPass', JSON.stringify(smashOrPass));
+        sessionStorage.setItem('smashCount', smashCount);
         // fetch next pokemon
         fetch(`https://pokeapi.co/api/v2/pokemon/${pokemon.shift()}`).then(res => res.json()).then(res => {
             sessionStorage.setItem('pokemon', JSON.stringify(pokemon));
@@ -68,12 +100,22 @@ pass.addEventListener('click', (e) => {
     pass.disabled = true;
     const pokemon = JSON.parse(sessionStorage.getItem('pokemon'));
     const smashOrPass = JSON.parse(sessionStorage.getItem('smashOrPass'));
+    var passCount = JSON.parse(sessionStorage.getItem('passCount'));
+    var smashCount = JSON.parse(sessionStorage.getItem('smashCount'));
 
     if (e.isTrusted) {
         // push to array
         smashOrPass.push(JSON.stringify({type: "pass", name: sessionStorage.getItem('currentPokemon') ?? 'bulbasaur'}));
+        // add to counter
+        passCount++;
         // add to list
         passPokemon.innerHTML += `<em><p>${sessionStorage.getItem('currentPokemon') ?? 'bulbasaur'}</p></em>`;
+        // add to displayed number
+        passNum.innerHTML = "Total: " + passCount;
+
+        // Display the percentage
+        smashPercentage.innerHTML = Math.round((smashCount / (smashCount + passCount)) * 100) + "% Smash";
+
         // if current pokemon is the same or doesn't exist
         if (currentPokemon === pokemon[0] || currentPokemon === null) pokemon.shift();
         // set session storage for current pokemon
@@ -81,6 +123,7 @@ pass.addEventListener('click', (e) => {
         pokemonName.innerText = sessionStorage.getItem('currentPokemon');
         // set session storage for smash or pass
         sessionStorage.setItem('smashOrPass', JSON.stringify(smashOrPass));
+        sessionStorage.setItem('passCount', passCount);
         // fetch next pokemon
         fetch(`https://pokeapi.co/api/v2/pokemon/${pokemon.shift()}`).then(res => res.json()).then(res => {
             sessionStorage.setItem('pokemon', JSON.stringify(pokemon));

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -50,10 +50,13 @@
                                     <button id="pass" class="noto-sans border-4 border-solid border-red-700 text-white rounded-xl bg-red-600 hover:bg-red-700 py-4 px-7">Pass</button>
                                 </div>
                             </div>
+                            <div class="flex-1 mt-5">
+                                <h1 class="text-2xl drop-shadow-md mb-1 pb-1 sticky top-0 backdrop-blur-sm" id="smashPercentage"></h1>
+                            </div>
                             <div class="flex-1 mt-6">
                                 <div class="grid auto-rows-auto	grid-cols-2 gap-x-7 text-center w-64">
-                                    <div class="scrollbar border-solid border-2 rounded-xl pb-2 border-lime-500 bg-lime-800/25 hover:bg-lime-800/30 overflow-auto h-64 text-white"><h4 class="text-2xl drop-shadow-md mb-1 pb-1 sticky top-0 backdrop-blur-sm">Smash</h4><div id="smashPokemon"></div></div>
-                                    <div class="scrollbar border-solid border-2 rounded-xl pb-2 border-red-500 bg-red-800/25 hover:bg-red-800/30 overflow-auto h-64 text-white"><h4 class="text-2xl drop-shadow-md mb-1 pb-1 sticky top-0 backdrop-blur-sm">Pass</h4><div id="passPokemon"></div></div>
+                                    <div class="scrollbar border-solid border-2 rounded-xl pb-2 border-lime-500 bg-lime-800/25 hover:bg-lime-800/30 overflow-auto h-64 text-white"><h4 class="text-2xl drop-shadow-md mb-1 pb-1 sticky top-0 backdrop-blur-sm">Smash</h4><h3 class="text-2xl drop-shadow-md mb-1 pb-1 sticky top-0 backdrop-blur-sm" id="smashNum"></h3><div id="smashPokemon"></div></div>
+                                    <div class="scrollbar border-solid border-2 rounded-xl pb-2 border-red-500 bg-red-800/25 hover:bg-red-800/30 overflow-auto h-64 text-white"><h4 class="text-2xl drop-shadow-md mb-1 pb-1 sticky top-0 backdrop-blur-sm">Pass</h4><h3 class="text-2xl drop-shadow-md mb-1 pb-1 sticky top-0 backdrop-blur-sm" id="passNum"></h3><div id="passPokemon"></div></div>
                                 </div>
                             </div>
                         </div>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -55,8 +55,8 @@
                             </div>
                             <div class="flex-1 mt-6">
                                 <div class="grid auto-rows-auto	grid-cols-2 gap-x-7 text-center w-64">
-                                    <div class="scrollbar border-solid border-2 rounded-xl pb-2 border-lime-500 bg-lime-800/25 hover:bg-lime-800/30 overflow-auto h-64 text-white"><h4 class="text-2xl drop-shadow-md mb-1 pb-1 sticky top-0 backdrop-blur-sm">Smash</h4><h3 class="text-2xl drop-shadow-md mb-1 pb-1 sticky top-0 backdrop-blur-sm" id="smashNum"></h3><div id="smashPokemon"></div></div>
-                                    <div class="scrollbar border-solid border-2 rounded-xl pb-2 border-red-500 bg-red-800/25 hover:bg-red-800/30 overflow-auto h-64 text-white"><h4 class="text-2xl drop-shadow-md mb-1 pb-1 sticky top-0 backdrop-blur-sm">Pass</h4><h3 class="text-2xl drop-shadow-md mb-1 pb-1 sticky top-0 backdrop-blur-sm" id="passNum"></h3><div id="passPokemon"></div></div>
+                                    <div class="scrollbar border-solid border-2 rounded-xl pb-2 border-lime-500 bg-lime-800/25 hover:bg-lime-800/30 overflow-auto h-64 text-white"><h4 class="text-2xl drop-shadow-md mb-1 pt-0 pb-0 sticky top-0 backdrop-blur-sm z-10">Smash</h4><h3 class="text-1xl drop-shadow-md mb-1 pb-1 sticky top-0 text-slate-300/75" id="smashNum"></h3><div id="smashPokemon"></div></div>
+                                    <div class="scrollbar border-solid border-2 rounded-xl pb-2 border-red-500 bg-red-800/25 hover:bg-red-800/30 overflow-auto h-64 text-white"><h4 class="text-2xl drop-shadow-md mb-1 pt-0 pb-0 sticky top-0 backdrop-blur-sm z-10">Pass</h4><h3 class="text-1xl drop-shadow-md mb-1 pb-1 sticky top-0 text-slate-300/75" id="passNum"></h3><div id="passPokemon"></div></div>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
This will forever be in my GitHub history.. I will probably regret this.

This PR adds a total counter for the smash and pass list, and shows a percentage above them.

The page looks like this after this PR.
![2022-02-14_23-05](https://user-images.githubusercontent.com/56408488/153954642-15a52614-e51e-49e6-abfe-1e967394195b.png)
You can see that the counters are stored in session storage. If the page hasn't been used yet, the percentage is hidden.

This is my first time doing anything with JS and HTML so if I've messed something up lemme know.